### PR TITLE
Fix Markdown Linter Warnings

### DIFF
--- a/install-prompts/android-openfeature.md
+++ b/install-prompts/android-openfeature.md
@@ -3,6 +3,7 @@
 You are helping to install and configure the DevCycle OpenFeature Provider for Android applications. Follow this complete guide to successfully integrate DevCycle feature flags using the OpenFeature standard. Do not install any Variables as part of this process, the user can ask for you to do that later.
 
 **Do not use this for:**
+
 - React Native apps (use React Native SDK instead)
 - Flutter apps (use Flutter SDK instead)
 - Web applications (use JavaScript/React SDKs instead)
@@ -11,6 +12,7 @@ You are helping to install and configure the DevCycle OpenFeature Provider for A
 ## Required Information
 
 Before proceeding, use your own analysis, the DevCycle MCP or web search to ensure you have:
+
 - [ ] A DevCycle account and project set up
 - [ ] A Development environment **Mobile SDK Key** (starts with `dvc_mobile_`)
 - [ ] Android project with minimum API level 21 (Android 5.0)
@@ -26,6 +28,7 @@ Before proceeding, use your own analysis, the DevCycle MCP or web search to ensu
 #### For Gradle (build.gradle or build.gradle.kts)
 
 **In your module-level build.gradle file:**
+
 ```groovy
 dependencies {
     implementation 'dev.openfeature:android-sdk:0.2.0'
@@ -35,6 +38,7 @@ dependencies {
 ```
 
 **For Kotlin DSL (build.gradle.kts):**
+
 ```kotlin
 dependencies {
     implementation("dev.openfeature:android-sdk:0.2.0")
@@ -58,6 +62,7 @@ Create or update your Application class:
 #### For Kotlin Projects
 
 **Application.kt:**
+
 ```kotlin
 import android.app.Application
 import dev.openfeature.sdk.OpenFeatureAPI
@@ -110,6 +115,7 @@ class MyApplication : Application() {
 #### For Java Projects
 
 **MyApplication.java:**
+
 ```java
 import android.app.Application;
 import dev.openfeature.sdk.OpenFeatureAPI;
@@ -286,6 +292,7 @@ After installation, build and run your Android application to verify everything 
 Suggest these as next steps to the user.
 
 After successful installation:
+
 1. Create feature flags via the DevCycle MCP
 2. Implement feature flag-based UI logic
 3. Set up proper error handling
@@ -302,6 +309,7 @@ After successful installation:
 ## Support
 
 If you encounter issues:
+
 1. Check the official documentation
 2. Review the troubleshooting section above
 3. Contact DevCycle support through the dashboard

--- a/install-prompts/android.md
+++ b/install-prompts/android.md
@@ -3,12 +3,14 @@
 You are helping to install and configure the DevCycle Android SDK in an Android application. Follow this complete guide to successfully integrate DevCycle feature flags. Do not install any Variables as part of this process, the user can ask for you to do that later.
 
 **IMPORTANT: First detect the project configuration:**
+
 - Check if the project uses Kotlin or Java
 - Identify the build system: Gradle (most common) or Maven
 - Check the minimum Android SDK version (requires API 21+)
 - Use the appropriate code examples based on the detected language
 
 **Do not use the SDK for:**
+
 - React Native apps (use `@devcycle/react-native-client-sdk` instead)
 - Flutter apps (use the Flutter SDK instead)
 - Web applications (use JavaScript/React/Angular SDKs instead)
@@ -19,6 +21,7 @@ If you detect that the user is trying to have you install the Android SDK in an 
 ## Required Information
 
 Before proceeding, use your own analysis, the DevCycle MCP or web search to ensure you have:
+
 - [ ] A DevCycle account and project set up
 - [ ] A Development environment **Mobile SDK Key** (starts with `dvc_mobile_`)
 - [ ] Android project with minimum API level 21 (Android 5.0)
@@ -34,6 +37,7 @@ Before proceeding, use your own analysis, the DevCycle MCP or web search to ensu
 #### For Gradle (build.gradle or build.gradle.kts)
 
 **In your module-level build.gradle file:**
+
 ```groovy
 dependencies {
     implementation 'com.devcycle:android-client-sdk:2.+'
@@ -41,6 +45,7 @@ dependencies {
 ```
 
 **For Kotlin DSL (build.gradle.kts):**
+
 ```kotlin
 dependencies {
     implementation("com.devcycle:android-client-sdk:2.+")
@@ -72,6 +77,7 @@ Create or update your Application class:
 #### For Kotlin Projects
 
 **Application.kt:**
+
 ```kotlin
 import android.app.Application
 import com.devcycle.sdk.android.api.DVCClient
@@ -112,6 +118,7 @@ class MyApplication : Application() {
 #### For Java Projects
 
 **MyApplication.java:**
+
 ```java
 import android.app.Application;
 import com.devcycle.sdk.android.api.DVCClient;
@@ -170,6 +177,7 @@ In your `AndroidManifest.xml`, register your custom Application class:
 ### 5. Store Your SDK Key Securely
 
 Instead of hardcoding the SDK key, consider using:
+
 - BuildConfig fields
 - Android resource files
 - Secure key management solutions
@@ -205,6 +213,7 @@ After installation, build and run your application to verify everything works wi
 Suggest these as next steps to the user.
 
 After successful installation:
+
 1. Update the user object with real user data when available
 2. Create your first feature flag via the DevCycle MCP and use it in your app
 3. Learn how to use variables throughout your Android application
@@ -222,6 +231,7 @@ After successful installation:
 ## Support
 
 If you encounter issues:
+
 1. Check the official documentation
 2. Review the troubleshooting section above
 3. Contact DevCycle support through the dashboard

--- a/install-prompts/angular.md
+++ b/install-prompts/angular.md
@@ -3,6 +3,7 @@
 You are helping to install and configure the DevCycle Angular SDK in an Angular application. Follow this complete guide to successfully integrate DevCycle feature flags. Do not install any Variables as part of this process, the user can ask for you to do that later.
 
 **Do not use the SDK for:**
+
 - React applications (use `@devcycle/react-client-sdk` instead)
 - Next.js applications (use `@devcycle/nextjs-sdk` instead)
 - Plain JavaScript/TypeScript web apps (use `@devcycle/js-client-sdk` instead)
@@ -14,6 +15,7 @@ If you detect that the user is trying to have you install the Angular SDK in an 
 ## Required Information
 
 Before proceeding, use your own analysis, the DevCycle MCP or web search to ensure you have:
+
 - [ ] A DevCycle account and project set up
 - [ ] A Development environment **Client SDK Key** (starts with `dvc_client_`)
 - [ ] Angular application (Angular 12+)
@@ -80,6 +82,7 @@ export class AppModule { }
 Create or update your environment files to store the SDK key:
 
 In `src/environments/environment.ts`:
+
 ```typescript
 export const environment = {
   production: false,
@@ -88,6 +91,7 @@ export const environment = {
 ```
 
 In `src/environments/environment.prod.ts`:
+
 ```typescript
 export const environment = {
   production: true,
@@ -96,6 +100,7 @@ export const environment = {
 ```
 
 Then update your module to use the environment variable:
+
 ```typescript
 import { environment } from '../environments/environment'
 
@@ -132,6 +137,7 @@ After installation, run your Angular application and verify everything runs with
 Suggest these as next steps to the user.
 
 After successful installation:
+
 1. Update the user context with real user data when users log in
 2. Create your first feature flag via the DevCycle MCP and use it in your components
 3. Learn how to use feature flags in your Angular components
@@ -149,6 +155,7 @@ After successful installation:
 ## Support
 
 If you encounter issues:
+
 1. Check the official documentation
 2. Review the troubleshooting section above
 3. Contact DevCycle support through the dashboard

--- a/install-prompts/dotnet-openfeature.md
+++ b/install-prompts/dotnet-openfeature.md
@@ -3,6 +3,7 @@
 You are helping to install and configure the DevCycle OpenFeature Provider for .NET server applications. Follow this complete guide to successfully integrate DevCycle feature flags using the OpenFeature standard. Do not install any Variables as part of this process, the user can ask for you to do that later.
 
 **Do not use this for:**
+
 - Client-side Blazor WebAssembly (use appropriate client SDK approach)
 - Unity games (consider Unity-specific patterns)
 - Mobile applications (use iOS/Android SDKs instead)
@@ -10,6 +11,7 @@ You are helping to install and configure the DevCycle OpenFeature Provider for .
 ## Required Information
 
 Before proceeding, use your own analysis, the DevCycle MCP or web search to ensure you have:
+
 - [ ] A DevCycle account and project set up
 - [ ] A Development environment **Server SDK Key** (starts with `dvc_server_`)
 - [ ] .NET Core 3.1+ or .NET 5+ installed
@@ -337,6 +339,7 @@ After installation, build and run your .NET application to verify everything wor
 Suggest these as next steps to the user.
 
 After successful installation:
+
 1. Create feature flags via the DevCycle MCP
 2. Implement evaluation context strategies
 3. Set up proper error handling and logging
@@ -353,6 +356,7 @@ After successful installation:
 ## Support
 
 If you encounter issues:
+
 1. Check the official documentation
 2. Review the troubleshooting section above
 3. Contact DevCycle support through the dashboard

--- a/install-prompts/dotnet.md
+++ b/install-prompts/dotnet.md
@@ -3,11 +3,13 @@
 You are helping to install and configure the DevCycle .NET SDK in a .NET server application. Follow this complete guide to successfully integrate DevCycle feature flags. Do not install any Variables as part of this process, the user can ask for you to do that later.
 
 **IMPORTANT: First detect the project configuration:**
+
 - Check the .NET version (.NET Core 3.1+ or .NET 5+)
 - Identify the project type: ASP.NET Core, Console App, or other
 - Check the package manager: NuGet Package Manager, .NET CLI, or PackageReference
 
 **Do not use the SDK for:**
+
 - Client-side Blazor WebAssembly (use appropriate client SDK approach)
 - Unity games (consider Unity-specific patterns)
 - Mobile applications (use iOS/Android SDKs instead)
@@ -17,6 +19,7 @@ If you detect that the user is trying to have you install the .NET SDK in an app
 ## Required Information
 
 Before proceeding, use your own analysis, the DevCycle MCP or web search to ensure you have:
+
 - [ ] A DevCycle account and project set up
 - [ ] A Development environment **Server SDK Key** (starts with `dvc_server_`)
 - [ ] .NET Core 3.1+ or .NET 5+ installed
@@ -307,9 +310,13 @@ After installation, build and run your .NET application to verify everything wor
 Suggest these as next steps to the user.
 
 After successful installation:
+
 1. Set up user identification logic for your application
+
 2. Create your first feature flag via the DevCycle MCP and use it in your controllers
+
 3. Implement proper error handling and logging
+
 4. Set up targeting rules for different user segments
 
 ## Helpful Resources
@@ -324,7 +331,11 @@ After successful installation:
 ## Support
 
 If you encounter issues:
+
 1. Check the official documentation
+
 2. Review the troubleshooting section above
+
 3. Contact DevCycle support through the dashboard
+
 4. Check the GitHub repository for known issues

--- a/install-prompts/flutter.md
+++ b/install-prompts/flutter.md
@@ -3,6 +3,7 @@
 You are helping to install and configure the DevCycle Flutter SDK in a Flutter application. Follow this complete guide to successfully integrate DevCycle feature flags. Do not install any Variables as part of this process, the user can ask for you to do that later.
 
 **Do not use the SDK for:**
+
 - React Native apps (use `@devcycle/react-native-client-sdk` instead)
 - Native iOS apps (use iOS SDK instead)
 - Native Android apps (use Android SDK instead)
@@ -13,6 +14,7 @@ If you detect that the user is trying to have you install the Flutter SDK in an 
 ## Required Information
 
 Before proceeding, use your own analysis, the DevCycle MCP or web search to ensure you have:
+
 - [ ] A DevCycle account and project set up
 - [ ] A Development environment **Mobile SDK Key** (starts with `dvc_mobile_`)
 - [ ] Flutter 2.0+ and Dart 2.12+ installed
@@ -33,6 +35,7 @@ dependencies:
 ```
 
 Then run:
+
 ```bash
 flutter pub get
 ```
@@ -44,6 +47,7 @@ flutter pub get
 No additional configuration required. The SDK automatically configures itself during the build process.
 
 **Note:** Ensure your iOS deployment target is set to iOS 11.0 or higher in `ios/Podfile`:
+
 ```ruby
 platform :ios, '11.0'
 ```
@@ -53,6 +57,7 @@ platform :ios, '11.0'
 No additional configuration required. The SDK automatically configures itself during the build process.
 
 **Note:** Ensure your minimum SDK version is API 21 or higher in `android/app/build.gradle`:
+
 ```groovy
 minSdkVersion 21
 ```
@@ -155,17 +160,18 @@ void main() async {
 For better security, use different configurations for different environments:
 
 1. Create environment configuration files:
-```dart
-// lib/config/dev_config.dart
-class DevConfig {
-  static const String devcycleSdkKey = 'your_dev_mobile_sdk_key';
-}
 
-// lib/config/prod_config.dart
-class ProdConfig {
-  static const String devcycleSdkKey = 'your_prod_mobile_sdk_key';
-}
-```
+    ```dart
+    // lib/config/dev_config.dart
+    class DevConfig {
+      static const String devcycleSdkKey = 'your_dev_mobile_sdk_key';
+    }
+
+    // lib/config/prod_config.dart
+    class ProdConfig {
+      static const String devcycleSdkKey = 'your_prod_mobile_sdk_key';
+    }
+    ```
 
 2. Use compile-time environment variables or build flavors to select the appropriate configuration.
 
@@ -199,6 +205,7 @@ After installation, run your application on both iOS and Android to verify every
 Suggest these as next steps to the user.
 
 After successful installation:
+
 1. Update the user object with real user data when available
 2. Create your first feature flag via the DevCycle MCP and use it in your app
 3. Learn how to use variables in your Flutter widgets
@@ -216,6 +223,7 @@ After successful installation:
 ## Support
 
 If you encounter issues:
+
 1. Check the official documentation
 2. Review the troubleshooting section above
 3. Contact DevCycle support through the dashboard

--- a/install-prompts/go-openfeature.md
+++ b/install-prompts/go-openfeature.md
@@ -3,12 +3,14 @@
 You are helping to install and configure the DevCycle OpenFeature Provider for Go server applications. Follow this complete guide to successfully integrate DevCycle feature flags using the OpenFeature standard. Do not install any Variables as part of this process, the user can ask for you to do that later.
 
 **Do not use this for:**
+
 - Client-side applications (use appropriate client SDKs instead)
 - Applications already using the DevCycle Go SDK directly
 
 ## Required Information
 
 Before proceeding, use your own analysis, the DevCycle MCP or web search to ensure you have:
+
 - [ ] A DevCycle account and project set up
 - [ ] A Development environment **Server SDK Key** (starts with `dvc_server_`)
 - [ ] Go 1.19+ installed
@@ -299,6 +301,7 @@ GO_ENV=development
 ```
 
 Load with godotenv:
+
 ```bash
 go get github.com/joho/godotenv
 ```
@@ -338,6 +341,7 @@ After installation, run your Go application and verify everything works with no 
 Suggest these as next steps to the user.
 
 After successful installation:
+
 1. Create feature flags via the DevCycle MCP
 2. Implement evaluation context strategies
 3. Set up proper error handling and fallbacks
@@ -354,6 +358,7 @@ After successful installation:
 ## Support
 
 If you encounter issues:
+
 1. Check the official documentation
 2. Review the troubleshooting section above
 3. Contact DevCycle support through the dashboard

--- a/install-prompts/go.md
+++ b/install-prompts/go.md
@@ -3,6 +3,7 @@
 You are helping to install and configure the DevCycle Go SDK in a Go server application. Follow this complete guide to successfully integrate DevCycle feature flags. Do not install any Variables as part of this process, the user can ask for you to do that later.
 
 **Do not use the SDK for:**
+
 - Client-side applications (use appropriate client SDKs instead)
 - JavaScript/Node.js applications (use Node.js SDK instead)
 - Mobile applications (use iOS/Android SDKs instead)
@@ -12,6 +13,7 @@ If you detect that the user is trying to have you install the Go SDK in an appli
 ## Required Information
 
 Before proceeding, use your own analysis, the DevCycle MCP or web search to ensure you have:
+
 - [ ] A DevCycle account and project set up
 - [ ] A Development environment **Server SDK Key** (starts with `dvc_server_`)
 - [ ] Go 1.16+ installed
@@ -276,6 +278,7 @@ After installation, run your Go application and verify everything works with no 
 Suggest these as next steps to the user.
 
 After successful installation:
+
 1. Set up user identification logic for your application
 2. Create your first feature flag via the DevCycle MCP and use it in your handlers
 3. Implement proper error handling for feature flag evaluations
@@ -293,6 +296,7 @@ After successful installation:
 ## Support
 
 If you encounter issues:
+
 1. Check the official documentation
 2. Review the troubleshooting section above
 3. Contact DevCycle support through the dashboard

--- a/install-prompts/ios-openfeature.md
+++ b/install-prompts/ios-openfeature.md
@@ -3,6 +3,7 @@
 You are helping to install and configure the DevCycle OpenFeature Provider for iOS applications. Follow this complete guide to successfully integrate DevCycle feature flags using the OpenFeature standard. Do not install any Variables as part of this process, the user can ask for you to do that later.
 
 **Do not use this for:**
+
 - React Native apps (use React Native SDK instead)
 - Flutter apps (use Flutter SDK instead)
 - Web applications (use JavaScript/React SDKs instead)
@@ -10,6 +11,7 @@ You are helping to install and configure the DevCycle OpenFeature Provider for i
 ## Required Information
 
 Before proceeding, use your own analysis, the DevCycle MCP or web search to ensure you have:
+
 - [ ] A DevCycle account and project set up
 - [ ] A Development environment **Mobile SDK Key** (starts with `dvc_mobile_`)
 - [ ] iOS 12.0+ / macOS 10.13+ / tvOS 12.0+ / watchOS 7.0+
@@ -34,6 +36,7 @@ dependencies: [
 ```
 
 Or via Xcode:
+
 1. File > Add Package Dependencies
 2. Add OpenFeature Swift SDK: `https://github.com/open-feature/swift-sdk.git`
 3. Add DevCycle iOS SDK: `https://github.com/DevCycleHQ/ios-client-sdk.git`
@@ -48,6 +51,7 @@ pod 'DevCycle'
 ```
 
 Then run:
+
 ```bash
 pod install
 ```
@@ -238,6 +242,7 @@ After installation, build and run your iOS application to verify everything work
 Suggest these as next steps to the user.
 
 After successful installation:
+
 1. Create feature flags via the DevCycle MCP
 2. Implement feature flag-based UI logic
 3. Set up proper error handling
@@ -254,6 +259,7 @@ After successful installation:
 ## Support
 
 If you encounter issues:
+
 1. Check the official documentation
 2. Review the troubleshooting section above
 3. Contact DevCycle support through the dashboard

--- a/install-prompts/ios.md
+++ b/install-prompts/ios.md
@@ -3,11 +3,13 @@
 You are helping to install and configure the DevCycle iOS SDK in an iOS application. Follow this complete guide to successfully integrate DevCycle feature flags. Do not install any Variables as part of this process, the user can ask for you to do that later.
 
 **IMPORTANT: First detect which language and package manager the project uses:**
+
 - Check if the project uses Swift or Objective-C
 - Identify the package manager: Swift Package Manager (Package.swift or Xcode packages), CocoaPods (Podfile), or Carthage (Cartfile)
 - Use the appropriate code examples based on the detected language
 
 **Do not use the SDK for:**
+
 - React Native apps (use `@devcycle/react-native-client-sdk` instead)
 - Flutter apps (use the Flutter SDK instead)
 - Web applications (use JavaScript/React/Angular SDKs instead)
@@ -18,6 +20,7 @@ If you detect that the user is trying to have you install the iOS SDK in an appl
 ## Required Information
 
 Before proceeding, use your own analysis, the DevCycle MCP or web search to ensure you have:
+
 - [ ] A DevCycle account and project set up
 - [ ] A Development environment **Mobile SDK Key** (starts with `dvc_mobile_`)
 - [ ] iOS 12.0+ / macOS 10.13+ / tvOS 12.0+ / watchOS 7.0+
@@ -35,6 +38,7 @@ Choose the installation method based on the detected package manager:
 #### Swift Package Manager (Recommended)
 
 **In Package.swift:**
+
 ```swift
 dependencies: [
     .package(url: "https://github.com/DevCycleHQ/ios-client-sdk.git", .upToNextMajor(from: "1.19.0"))
@@ -48,6 +52,7 @@ targets: [
 ```
 
 **Or via Xcode:**
+
 1. File > Add Package Dependencies
 2. Enter: `https://github.com/DevCycleHQ/ios-client-sdk.git`
 3. Choose version rule: Up to Next Major Version
@@ -56,11 +61,13 @@ targets: [
 #### CocoaPods
 
 Add to your `Podfile`:
+
 ```ruby
 pod 'DevCycle'
 ```
 
 Then run:
+
 ```bash
 pod install
 ```
@@ -68,11 +75,13 @@ pod install
 #### Carthage
 
 Add to your `Cartfile`:
-```
+
+```text
 github "DevCycleHQ/ios-client-sdk"
 ```
 
 Then run:
+
 ```bash
 carthage update --platform iOS --use-xcframeworks
 ```
@@ -166,6 +175,7 @@ For Swift, you can pass the client instance through dependency injection or make
 ### 4. Store Your SDK Key Securely
 
 Instead of hardcoding the SDK key, consider using:
+
 - Xcode configuration files (.xcconfig)
 - Environment variables
 - Secure key management solutions
@@ -199,6 +209,7 @@ After installation, build and run your application to verify everything works wi
 Suggest these as next steps to the user.
 
 After successful installation:
+
 1. Update the user object with real user data when available
 2. Create your first feature flag via the DevCycle MCP and use it in your app
 3. Learn how to use variables throughout your iOS application
@@ -216,6 +227,7 @@ After successful installation:
 ## Support
 
 If you encounter issues:
+
 1. Check the official documentation
 2. Review the troubleshooting section above
 3. Contact DevCycle support through the dashboard

--- a/install-prompts/java-openfeature.md
+++ b/install-prompts/java-openfeature.md
@@ -3,12 +3,14 @@
 You are helping to install and configure the DevCycle OpenFeature Provider for Java server applications. Follow this complete guide to successfully integrate DevCycle feature flags using the OpenFeature standard. Do not install any Variables as part of this process, the user can ask for you to do that later.
 
 **Do not use this for:**
+
 - Android applications (use Android SDK instead)
 - Client-side applications (use appropriate client SDKs instead)
 
 ## Required Information
 
 Before proceeding, use your own analysis, the DevCycle MCP or web search to ensure you have:
+
 - [ ] A DevCycle account and project set up
 - [ ] A Development environment **Server SDK Key** (starts with `dvc_server_`)
 - [ ] Java 8+ installed
@@ -296,6 +298,7 @@ After installation, build and run your Java application to verify everything wor
 Suggest these as next steps to the user.
 
 After successful installation:
+
 1. Create feature flags via the DevCycle MCP
 2. Implement evaluation context strategies
 3. Set up proper error handling and fallbacks
@@ -312,6 +315,7 @@ After successful installation:
 ## Support
 
 If you encounter issues:
+
 1. Check the official documentation
 2. Review the troubleshooting section above
 3. Contact DevCycle support through the dashboard

--- a/install-prompts/java.md
+++ b/install-prompts/java.md
@@ -3,11 +3,13 @@
 You are helping to install and configure the DevCycle Java SDK in a Java server application. Follow this complete guide to successfully integrate DevCycle feature flags. Do not install any Variables as part of this process, the user can ask for you to do that later.
 
 **IMPORTANT: First detect the project configuration:**
+
 - Check the build system: Maven (pom.xml) or Gradle (build.gradle)
 - Identify the framework: Spring Boot, Micronaut, Quarkus, or plain Java
 - Check Java version (requires Java 8+)
 
 **Do not use the SDK for:**
+
 - Android applications (use Android SDK instead)
 - Client-side applications (use appropriate client SDKs instead)
 - Kotlin-only projects (while compatible, consider Kotlin-specific patterns)
@@ -17,6 +19,7 @@ If you detect that the user is trying to have you install the Java SDK in an app
 ## Required Information
 
 Before proceeding, use your own analysis, the DevCycle MCP or web search to ensure you have:
+
 - [ ] A DevCycle account and project set up
 - [ ] A Development environment **Server SDK Key** (starts with `dvc_server_`)
 - [ ] Java 8+ installed
@@ -155,10 +158,14 @@ public class DevCycleSpringConfig {
 
 Add to `application.properties` or `application.yml`:
 
+**application.properties:**
+
 ```properties
 # application.properties
 devcycle.server.sdk.key=${DEVCYCLE_SERVER_SDK_KEY:your_default_key_here}
 ```
+
+**application.yml:**
 
 ```yaml
 # application.yml
@@ -258,6 +265,7 @@ After installation, build and run your Java application to verify everything wor
 Suggest these as next steps to the user.
 
 After successful installation:
+
 1. Set up user identification logic for your application
 2. Create your first feature flag via the DevCycle MCP and use it in your services
 3. Implement proper error handling for feature flag evaluations
@@ -275,6 +283,7 @@ After successful installation:
 ## Support
 
 If you encounter issues:
+
 1. Check the official documentation
 2. Review the troubleshooting section above
 3. Contact DevCycle support through the dashboard

--- a/install-prompts/javascript-openfeature.md
+++ b/install-prompts/javascript-openfeature.md
@@ -3,6 +3,7 @@
 You are helping to install and configure the DevCycle OpenFeature Provider for JavaScript web applications. Follow this complete guide to successfully integrate DevCycle feature flags using the OpenFeature standard. Do not install any Variables as part of this process, the user can ask for you to do that later.
 
 **Do not use this for:**
+
 - React applications (use `javascript-openfeature.md` or `react-openfeature.md` instead)
 - Node.js server applications (use `nodejs-openfeature.md` instead)
 - Applications already using the DevCycle JavaScript SDK directly
@@ -10,6 +11,7 @@ You are helping to install and configure the DevCycle OpenFeature Provider for J
 ## Required Information
 
 Before proceeding, use your own analysis, the DevCycle MCP or web search to ensure you have:
+
 - [ ] A DevCycle account and project set up
 - [ ] A Development environment **Client SDK Key** (starts with `dvc_client_`)
 - [ ] JavaScript application or website
@@ -174,6 +176,7 @@ After installation, run your application and verify everything works with no err
 Suggest these as next steps to the user.
 
 After successful installation:
+
 1. Create your first feature flag via the DevCycle MCP
 2. Set up event tracking for feature flag evaluations
 3. Implement proper error handling
@@ -190,6 +193,7 @@ After successful installation:
 ## Support
 
 If you encounter issues:
+
 1. Check the official documentation
 2. Review the troubleshooting section above
 3. Contact DevCycle support through the dashboard

--- a/install-prompts/javascript.md
+++ b/install-prompts/javascript.md
@@ -3,6 +3,7 @@
 You are helping to install and configure the DevCycle JavaScript SDK in a web application. Follow this complete guide to successfully integrate DevCycle feature flags. Do not install any Variables as part of this process, the user can ask for you to do that later.
 
 **Do not use the SDK for:**
+
 - React applications (use `@devcycle/react-client-sdk` instead)
 - Next.js applications (use `@devcycle/nextjs-sdk` instead)
 - Angular applications (use `@devcycle/angular-client-sdk` instead)
@@ -14,6 +15,7 @@ If you detect that the user is trying to have you install the JavaScript SDK in 
 ## Required Information
 
 Before proceeding, use your own analysis, the DevCycle MCP or web search to ensure you have:
+
 - [ ] A DevCycle account and project set up
 - [ ] A Development environment **Client SDK Key** (starts with `dvc_client_`)
 - [ ] A JavaScript application or website
@@ -134,6 +136,7 @@ After installation, verify everything runs with no errors.
 Suggest these as next steps to the user.
 
 After successful installation:
+
 1. Create your first feature flag via the DevCycle MCP and wrap your code in its Variable
 2. Set up targeting rules for different user segments
 3. Implement proper error handling around feature flag evaluations
@@ -150,6 +153,7 @@ After successful installation:
 ## Support
 
 If you encounter issues:
+
 1. Check the official documentation
 2. Review the troubleshooting section above
 3. Contact DevCycle support through the dashboard

--- a/install-prompts/nestjs-openfeature.md
+++ b/install-prompts/nestjs-openfeature.md
@@ -3,6 +3,7 @@
 You are helping to install and configure the DevCycle OpenFeature Provider for NestJS server applications. Follow this complete guide to successfully integrate DevCycle feature flags using the OpenFeature standard. Do not install any Variables as part of this process, the user can ask for you to do that later.
 
 **Do not use this for:**
+
 - Plain Node.js applications (use `nodejs-openfeature.md` instead)
 - Client-side applications (use appropriate client SDKs instead)
 - Express applications without NestJS (use Node.js OpenFeature instead)
@@ -10,6 +11,7 @@ You are helping to install and configure the DevCycle OpenFeature Provider for N
 ## Required Information
 
 Before proceeding, use your own analysis, the DevCycle MCP or web search to ensure you have:
+
 - [ ] A DevCycle account and project set up
 - [ ] A Development environment **Server SDK Key** (starts with `dvc_server_`)
 - [ ] NestJS 8+ installed
@@ -401,6 +403,7 @@ After installation, run your NestJS application and verify everything works with
 Suggest these as next steps to the user.
 
 After successful installation:
+
 1. Create feature flags via the DevCycle MCP
 2. Implement guards for feature-based route protection
 3. Set up evaluation context strategies
@@ -418,6 +421,7 @@ After successful installation:
 ## Support
 
 If you encounter issues:
+
 1. Check the official documentation
 2. Review the troubleshooting section above
 3. Contact DevCycle support through the dashboard

--- a/install-prompts/nestjs.md
+++ b/install-prompts/nestjs.md
@@ -3,6 +3,7 @@
 You are helping to install and configure the DevCycle SDK in a NestJS server application. Follow this complete guide to successfully integrate DevCycle feature flags. Do not install any Variables as part of this process, the user can ask for you to do that later.
 
 **Do not use the SDK for:**
+
 - Plain Node.js applications (use `@devcycle/nodejs-server-sdk` instead)
 - Client-side applications (use appropriate client SDKs instead)
 - Express applications without NestJS (use Node.js SDK instead)
@@ -12,6 +13,7 @@ If you detect that the user is trying to have you install the NestJS approach in
 ## Required Information
 
 Before proceeding, use your own analysis, the DevCycle MCP or web search to ensure you have:
+
 - [ ] A DevCycle account and project set up
 - [ ] A Development environment **Server SDK Key** (starts with `dvc_server_`)
 - [ ] NestJS 8+ installed
@@ -329,6 +331,7 @@ After installation, run your NestJS application and verify everything works with
 Suggest these as next steps to the user.
 
 After successful installation:
+
 1. Set up user identification logic for your application
 2. Create your first feature flag via the DevCycle MCP and use it in your services
 3. Implement guards for feature-based route protection
@@ -346,6 +349,7 @@ After successful installation:
 ## Support
 
 If you encounter issues:
+
 1. Check the official documentation
 2. Review the troubleshooting section above
 3. Contact DevCycle support through the dashboard

--- a/install-prompts/nextjs.md
+++ b/install-prompts/nextjs.md
@@ -3,6 +3,7 @@
 You are helping to install and configure the DevCycle Next.js SDK in a Next.js application. Follow this complete guide to successfully integrate DevCycle feature flags. Do not install any Variables as part of this process, the user can ask for you to do that later.
 
 **Do not use the SDK for:**
+
 - React applications without Next.js (use `@devcycle/react-client-sdk` instead)
 - Plain JavaScript/TypeScript web apps (use `@devcycle/js-client-sdk` instead)
 - React Native mobile apps (use `@devcycle/react-native-client-sdk`)
@@ -13,6 +14,7 @@ If you detect that the user is trying to have you install the Next.js SDK in an 
 ## Required Information
 
 Before proceeding, use your own analysis, the DevCycle MCP or web search to ensure you have:
+
 - [ ] A DevCycle account and project set up
 - [ ] A Development environment **Server SDK Key** (starts with `dvc_server_`)
 - [ ] A Development environment **Client SDK Key** (starts with `dvc_client_`)
@@ -49,6 +51,7 @@ If using TypeScript with App Router, ensure your `tsconfig.json` includes:
 ```
 
 Required minimum versions for TypeScript:
+
 - TypeScript: 5.1.3+
 - @types/react: 18.2.8+
 
@@ -114,7 +117,7 @@ NEXT_PUBLIC_DEVCYCLE_CLIENT_SDK_KEY=your_client_sdk_key_here
 
 **Important:** The client SDK key MUST be prefixed with `NEXT_PUBLIC_` to be available in browser code.
 
-## Setup for Pages Router (Legacy)
+## Setup for Pages Router
 
 ### 3. Wrap Your App Component
 
@@ -161,7 +164,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 }
 ```
 
-### 5. Set Environment Variables
+### 6. Set Environment Variables
 
 Create or update your `.env.local` file:
 
@@ -198,6 +201,7 @@ After installation, restart your development server and verify everything runs w
 Suggest these as next steps to the user.
 
 After successful installation:
+
 1. Customize the `getUserIdentity` function to fetch real user data
 2. Create your first feature flag via the DevCycle MCP and use it in your components
 3. Learn how to use variables in both server and client components
@@ -214,6 +218,7 @@ After successful installation:
 ## Support
 
 If you encounter issues:
+
 1. Check the official documentation
 2. Review the troubleshooting section above
 3. Contact DevCycle support through the dashboard

--- a/install-prompts/nodejs-openfeature.md
+++ b/install-prompts/nodejs-openfeature.md
@@ -3,6 +3,7 @@
 You are helping to install and configure the DevCycle OpenFeature Provider for Node.js server applications. Follow this complete guide to successfully integrate DevCycle feature flags using the OpenFeature standard. Do not install any Variables as part of this process, the user can ask for you to do that later.
 
 **Do not use this for:**
+
 - Client-side JavaScript applications (use `javascript-openfeature.md` instead)
 - React applications (use `react-openfeature.md` instead)
 - NestJS applications (consider NestJS-specific patterns)
@@ -10,6 +11,7 @@ You are helping to install and configure the DevCycle OpenFeature Provider for N
 ## Required Information
 
 Before proceeding, use your own analysis, the DevCycle MCP or web search to ensure you have:
+
 - [ ] A DevCycle account and project set up
 - [ ] A Development environment **Server SDK Key** (starts with `dvc_server_`)
 - [ ] Node.js 14+ installed
@@ -218,6 +220,7 @@ NODE_ENV=development
 ```
 
 Load with dotenv:
+
 ```javascript
 require('dotenv').config();
 ```
@@ -253,6 +256,7 @@ After installation, run your Node.js application and verify everything works wit
 Suggest these as next steps to the user.
 
 After successful installation:
+
 1. Create feature flags via the DevCycle MCP
 2. Implement evaluation context strategies
 3. Set up proper error handling and fallbacks
@@ -269,6 +273,7 @@ After successful installation:
 ## Support
 
 If you encounter issues:
+
 1. Check the official documentation
 2. Review the troubleshooting section above
 3. Contact DevCycle support through the dashboard

--- a/install-prompts/nodejs.md
+++ b/install-prompts/nodejs.md
@@ -3,6 +3,7 @@
 You are helping to install and configure the DevCycle Node.js SDK in a Node.js server application. Follow this complete guide to successfully integrate DevCycle feature flags. Do not install any Variables as part of this process, the user can ask for you to do that later.
 
 **Do not use the SDK for:**
+
 - Client-side JavaScript applications (use `@devcycle/js-client-sdk` instead)
 - React applications (use `@devcycle/react-client-sdk` instead)
 - Next.js applications (use `@devcycle/nextjs-sdk` instead)
@@ -13,6 +14,7 @@ If you detect that the user is trying to have you install the Node.js SDK in an 
 ## Required Information
 
 Before proceeding, use your own analysis, the DevCycle MCP or web search to ensure you have:
+
 - [ ] A DevCycle account and project set up
 - [ ] A Development environment **Server SDK Key** (starts with `dvc_server_`)
 - [ ] Node.js 12+ installed
@@ -166,11 +168,13 @@ NODE_ENV=development
 ```
 
 Install dotenv if not already installed:
+
 ```bash
 npm install --save dotenv
 ```
 
 Load environment variables at the top of your main file:
+
 ```javascript
 require('dotenv').config()
 ```
@@ -206,6 +210,7 @@ After installation, run your Node.js application and verify everything works wit
 Suggest these as next steps to the user.
 
 After successful installation:
+
 1. Set up user identification logic for your application
 2. Create your first feature flag via the DevCycle MCP and use it in your routes
 3. Implement proper error handling for feature flag evaluations
@@ -223,6 +228,7 @@ After successful installation:
 ## Support
 
 If you encounter issues:
+
 1. Check the official documentation
 2. Review the troubleshooting section above
 3. Contact DevCycle support through the dashboard

--- a/install-prompts/php-openfeature.md
+++ b/install-prompts/php-openfeature.md
@@ -3,6 +3,7 @@
 You are helping to install and configure the DevCycle OpenFeature Provider for PHP server applications. Follow this complete guide to successfully integrate DevCycle feature flags using the OpenFeature standard. Do not install any Variables as part of this process, the user can ask for you to do that later.
 
 **Do not use this for:**
+
 - Client-side applications (use appropriate client SDKs instead)
 - JavaScript/Node.js applications (use Node.js SDK instead)
 - Mobile applications (use iOS/Android SDKs instead)
@@ -10,6 +11,7 @@ You are helping to install and configure the DevCycle OpenFeature Provider for P
 ## Required Information
 
 Before proceeding, use your own analysis, the DevCycle MCP or web search to ensure you have:
+
 - [ ] A DevCycle account and project set up
 - [ ] A Development environment **Server SDK Key** (starts with `dvc_server_`)
 - [ ] PHP 7.4+ installed
@@ -339,6 +341,7 @@ After installation, run your PHP application and verify everything works with no
 Suggest these as next steps to the user.
 
 After successful installation:
+
 1. Create feature flags via the DevCycle MCP
 2. Implement evaluation context strategies
 3. Set up proper error handling and logging
@@ -355,6 +358,7 @@ After successful installation:
 ## Support
 
 If you encounter issues:
+
 1. Check the official documentation
 2. Review the troubleshooting section above
 3. Contact DevCycle support through the dashboard

--- a/install-prompts/php.md
+++ b/install-prompts/php.md
@@ -3,11 +3,13 @@
 You are helping to install and configure the DevCycle PHP SDK in a PHP server application. Follow this complete guide to successfully integrate DevCycle feature flags. Do not install any Variables as part of this process, the user can ask for you to do that later.
 
 **IMPORTANT: First detect the project configuration:**
+
 - Check if using Composer for dependency management
 - Identify the framework: Laravel, Symfony, Slim, or plain PHP
 - Check PHP version (requires PHP 7.4+)
 
 **Do not use the SDK for:**
+
 - Client-side applications (use appropriate client SDKs instead)
 - JavaScript/Node.js applications (use Node.js SDK instead)
 - Mobile applications (use iOS/Android SDKs instead)
@@ -17,6 +19,7 @@ If you detect that the user is trying to have you install the PHP SDK in an appl
 ## Required Information
 
 Before proceeding, use your own analysis, the DevCycle MCP or web search to ensure you have:
+
 - [ ] A DevCycle account and project set up
 - [ ] A Development environment **Server SDK Key** (starts with `dvc_server_`)
 - [ ] PHP 7.4+ installed
@@ -263,6 +266,7 @@ APP_ENV=development
 ```
 
 For plain PHP, install phpdotenv if needed:
+
 ```bash
 composer require vlucas/phpdotenv
 ```
@@ -298,6 +302,7 @@ After installation, run your PHP application and verify everything works with no
 Suggest these as next steps to the user.
 
 After successful installation:
+
 1. Set up user identification logic for your application
 2. Create your first feature flag via the DevCycle MCP and use it in your controllers
 3. Implement proper error handling for feature flag evaluations
@@ -315,6 +320,7 @@ After successful installation:
 ## Support
 
 If you encounter issues:
+
 1. Check the official documentation
 2. Review the troubleshooting section above
 3. Contact DevCycle support through the dashboard

--- a/install-prompts/python-openfeature.md
+++ b/install-prompts/python-openfeature.md
@@ -3,6 +3,7 @@
 You are helping to install and configure the DevCycle OpenFeature Provider for Python server applications. Follow this complete guide to successfully integrate DevCycle feature flags using the OpenFeature standard. Do not install any Variables as part of this process, the user can ask for you to do that later.
 
 **Do not use this for:**
+
 - Client-side applications (use appropriate client SDKs instead)
 - JavaScript/Node.js applications (use Node.js SDK instead)
 - Mobile applications (use iOS/Android SDKs instead)
@@ -10,6 +11,7 @@ You are helping to install and configure the DevCycle OpenFeature Provider for P
 ## Required Information
 
 Before proceeding, use your own analysis, the DevCycle MCP or web search to ensure you have:
+
 - [ ] A DevCycle account and project set up
 - [ ] A Development environment **Server SDK Key** (starts with `dvc_server_`)
 - [ ] Python 3.8+ installed
@@ -328,6 +330,7 @@ After installation, run your Python application and verify everything works with
 Suggest these as next steps to the user.
 
 After successful installation:
+
 1. Create feature flags via the DevCycle MCP
 2. Implement evaluation context strategies
 3. Set up proper error handling and logging
@@ -344,6 +347,7 @@ After successful installation:
 ## Support
 
 If you encounter issues:
+
 1. Check the official documentation
 2. Review the troubleshooting section above
 3. Contact DevCycle support through the dashboard

--- a/install-prompts/python.md
+++ b/install-prompts/python.md
@@ -3,6 +3,7 @@
 You are helping to install and configure the DevCycle Python SDK in a Python server application. Follow this complete guide to successfully integrate DevCycle feature flags. Do not install any Variables as part of this process, the user can ask for you to do that later.
 
 **Do not use the SDK for:**
+
 - Client-side applications (use appropriate client SDKs instead)
 - JavaScript/Node.js applications (use Node.js SDK instead)
 - Mobile applications (use iOS/Android SDKs instead)
@@ -12,6 +13,7 @@ If you detect that the user is trying to have you install the Python SDK in an a
 ## Required Information
 
 Before proceeding, use your own analysis, the DevCycle MCP or web search to ensure you have:
+
 - [ ] A DevCycle account and project set up
 - [ ] A Development environment **Server SDK Key** (starts with `dvc_server_`)
 - [ ] Python 3.7+ installed
@@ -180,11 +182,13 @@ ENVIRONMENT=development
 ```
 
 Install python-dotenv if not already installed:
+
 ```bash
 pip install python-dotenv
 ```
 
 Load environment variables in your main application:
+
 ```python
 from dotenv import load_dotenv
 
@@ -223,6 +227,7 @@ After installation, run your Python application and verify everything works with
 Suggest these as next steps to the user.
 
 After successful installation:
+
 1. Set up user identification logic for your application
 2. Create your first feature flag via the DevCycle MCP and use it in your routes
 3. Implement proper error handling for feature flag evaluations
@@ -240,6 +245,7 @@ After successful installation:
 ## Support
 
 If you encounter issues:
+
 1. Check the official documentation
 2. Review the troubleshooting section above
 3. Contact DevCycle support through the dashboard

--- a/install-prompts/react-native.md
+++ b/install-prompts/react-native.md
@@ -3,6 +3,7 @@
 You are helping to install and configure the DevCycle React Native SDK in a React Native application. Follow this complete guide to successfully integrate DevCycle feature flags. Do not install any Variables as part of this process, the user can ask for you to do that later.
 
 **Do not use the SDK for:**
+
 - React web applications (use `@devcycle/react-client-sdk` instead)
 - Native iOS apps (use iOS SDK instead)
 - Native Android apps (use Android SDK instead)
@@ -14,6 +15,7 @@ If you detect that the user is trying to have you install the React Native SDK i
 ## Required Information
 
 Before proceeding, use your own analysis, the DevCycle MCP or web search to ensure you have:
+
 - [ ] A DevCycle account and project set up
 - [ ] A Development environment **Mobile SDK Key** (starts with `dvc_mobile_`)
 - [ ] React Native 0.64+ installed
@@ -45,6 +47,7 @@ cd ios && pod install
 ```
 
 **Note:** Ensure your iOS deployment target is set to iOS 12.0 or higher in your `Podfile`:
+
 ```ruby
 platform :ios, '12.0'
 ```
@@ -54,6 +57,7 @@ platform :ios, '12.0'
 No additional setup required for Android. The SDK automatically configures itself during the build process.
 
 **Note:** Ensure your minimum SDK version is API 21 or higher in `android/build.gradle`:
+
 ```groovy
 minSdkVersion = 21
 ```
@@ -114,28 +118,31 @@ export default function App() {
 For better security, use environment variables:
 
 1. Install react-native-config:
-```bash
-npm install react-native-config
-```
+
+   ```bash
+   npm install react-native-config
+   ```
 
 2. Create `.env` files for different environments:
-```bash
-# .env.development
-DEVCYCLE_MOBILE_SDK_KEY=your_dev_mobile_sdk_key
 
-# .env.production
-DEVCYCLE_MOBILE_SDK_KEY=your_prod_mobile_sdk_key
-```
+   ```bash
+   # .env.development
+   DEVCYCLE_MOBILE_SDK_KEY=your_dev_mobile_sdk_key
+
+   # .env.production
+   DEVCYCLE_MOBILE_SDK_KEY=your_prod_mobile_sdk_key
+   ```
 
 3. Use in your code:
-```javascript
-import Config from 'react-native-config'
 
-export default withDevCycleProvider({
-  sdkKey: Config.DEVCYCLE_MOBILE_SDK_KEY,
-  user: { user_id: 'default-user' }
-})(App)
-```
+    ```javascript
+    import Config from 'react-native-config'
+
+    export default withDevCycleProvider({
+      sdkKey: Config.DEVCYCLE_MOBILE_SDK_KEY,
+      user: { user_id: 'default-user' }
+    })(App)
+    ```
 
 After installation, rebuild your application for both platforms and verify everything runs with no errors.
 
@@ -172,6 +179,7 @@ After installation, rebuild your application for both platforms and verify every
 Suggest these as next steps to the user.
 
 After successful installation:
+
 1. Update the user object with real user data when users log in
 2. Create your first feature flag via the DevCycle MCP and use it in your app
 3. Learn how to use feature flags with React Native hooks
@@ -189,6 +197,7 @@ After successful installation:
 ## Support
 
 If you encounter issues:
+
 1. Check the official documentation
 2. Review the troubleshooting section above
 3. Contact DevCycle support through the dashboard

--- a/install-prompts/react-openfeature.md
+++ b/install-prompts/react-openfeature.md
@@ -3,6 +3,7 @@
 You are helping to install and configure the DevCycle OpenFeature Provider for React applications. Follow this complete guide to successfully integrate DevCycle feature flags using the OpenFeature standard. Do not install any Variables as part of this process, the user can ask for you to do that later.
 
 **Do not use this for:**
+
 - Next.js applications (use Next.js SDK instead)
 - React Native apps (use React Native SDK instead)
 - Non-React JavaScript applications (use `javascript-openfeature.md` instead)
@@ -11,6 +12,7 @@ You are helping to install and configure the DevCycle OpenFeature Provider for R
 ## Required Information
 
 Before proceeding, use your own analysis, the DevCycle MCP or web search to ensure you have:
+
 - [ ] A DevCycle account and project set up
 - [ ] A Development environment **Client SDK Key** (starts with `dvc_client_`)
 - [ ] React 16.8+ installed (hooks support required)
@@ -243,6 +245,7 @@ After installation, run your React application and verify everything works with 
 Suggest these as next steps to the user.
 
 After successful installation:
+
 1. Create your first feature flag via the DevCycle MCP
 2. Implement feature flag-based routing
 3. Set up error boundaries for feature components
@@ -259,6 +262,7 @@ After successful installation:
 ## Support
 
 If you encounter issues:
+
 1. Check the official documentation
 2. Review the troubleshooting section above
 3. Contact DevCycle support through the dashboard

--- a/install-prompts/react.md
+++ b/install-prompts/react.md
@@ -3,6 +3,7 @@
 You are helping to install and configure the DevCycle React SDK in a React web application. Follow this complete guide to successfully integrate DevCycle feature flags. Do not install any Variables as part of this process, the user can ask for you to do that later.
 
 **Do not use the SDK for:**
+
 - Next.js applications (use `@devcycle/nextjs-sdk` instead)
 - React Native mobile apps (use `@devcycle/react-native-client-sdk`)
 - Server-side React rendering without browser context
@@ -13,6 +14,7 @@ If you detect that the user is trying to have you install the React SDK in an ap
 ## Required Information
 
 Before proceeding, use your own analysis, the DevCycle MCP or web search to ensure you have:
+
 - [ ] A DevCycle account and project set up
 - [ ] A Development environment **Client SDK Key** (starts with `dvc_client_`)
 - [ ] React 16.8+ installed in your project
@@ -64,7 +66,6 @@ export default withDevCycleProvider({
 
 After installation, verify everything runs with no errors.
 
-
 ## Troubleshooting
 
 **Common Issues:**
@@ -82,6 +83,7 @@ After installation, verify everything runs with no errors.
 Suggest these as next steps to the user.
 
 After successful installation:
+
 1. Create your first feature flag via the DevCycle MCP and wrap your code in its Variable
 2. Set up targeting rules for different user segments
 3. Implement proper error boundaries around feature-flagged components
@@ -97,6 +99,7 @@ After successful installation:
 ## Support
 
 If you encounter issues:
+
 1. Check the official documentation
 2. Review the troubleshooting section above
 3. Contact DevCycle support through the dashboard

--- a/install-prompts/roku.md
+++ b/install-prompts/roku.md
@@ -3,6 +3,7 @@
 You are helping to install and configure the DevCycle Roku SDK in a Roku channel application. Follow this complete guide to successfully integrate DevCycle feature flags. Do not install any Variables as part of this process, the user can ask for you to do that later.
 
 **Do not use the SDK for:**
+
 - Web applications (use JavaScript/React SDKs instead)
 - Mobile applications (use iOS/Android/React Native/Flutter SDKs instead)
 - Smart TV platforms other than Roku (use appropriate platform SDKs)
@@ -12,6 +13,7 @@ If you detect that the user is trying to have you install the Roku SDK in an app
 ## Required Information
 
 Before proceeding, use your own analysis, the DevCycle MCP or web search to ensure you have:
+
 - [ ] A DevCycle account and project set up
 - [ ] A Development environment **Mobile SDK Key** (starts with `dvc_mobile_`)
 - [ ] Roku development environment set up
@@ -30,7 +32,7 @@ Download the latest DevCycle Roku SDK from the GitHub releases or package reposi
 
 Copy the DevCycle SDK files to your Roku project's source directory:
 
-```
+```text
 your-roku-project/
 ├── source/
 │   ├── devcycle/
@@ -110,7 +112,7 @@ Create a DevCycle component file (`components/DevCycleClient.xml`):
 
 Ensure your `manifest` file includes necessary permissions:
 
-```
+```text
 title=Your Channel Name
 major_version=1
 minor_version=0
@@ -171,6 +173,7 @@ After installation, deploy your channel to a Roku device and verify everything r
 Suggest these as next steps to the user.
 
 After successful installation:
+
 1. Update the user object with real user data when available
 2. Create your first feature flag via the DevCycle MCP and use it in your channel
 3. Learn how to use variables throughout your Roku application
@@ -188,6 +191,7 @@ After successful installation:
 ## Support
 
 If you encounter issues:
+
 1. Check the official documentation
 2. Review the troubleshooting section above
 3. Contact DevCycle support through the dashboard

--- a/install-prompts/ruby-openfeature.md
+++ b/install-prompts/ruby-openfeature.md
@@ -3,6 +3,7 @@
 You are helping to install and configure the DevCycle OpenFeature Provider for Ruby server applications. Follow this complete guide to successfully integrate DevCycle feature flags using the OpenFeature standard. Do not install any Variables as part of this process, the user can ask for you to do that later.
 
 **Do not use this for:**
+
 - Client-side applications (use appropriate client SDKs instead)
 - JavaScript/Node.js applications (use Node.js SDK instead)
 - Mobile applications (use iOS/Android SDKs instead)
@@ -10,6 +11,7 @@ You are helping to install and configure the DevCycle OpenFeature Provider for R
 ## Required Information
 
 Before proceeding, use your own analysis, the DevCycle MCP or web search to ensure you have:
+
 - [ ] A DevCycle account and project set up
 - [ ] A Development environment **Server SDK Key** (starts with `dvc_server_`)
 - [ ] Ruby 2.7+ installed
@@ -31,11 +33,13 @@ gem 'devcycle-ruby-server-sdk-openfeature'
 ```
 
 Then run:
+
 ```bash
 bundle install
 ```
 
 Or install directly:
+
 ```bash
 gem install openfeature-sdk
 gem install devcycle-ruby-server-sdk
@@ -285,11 +289,13 @@ end
 Using dotenv for Rails/Ruby:
 
 Add to `Gemfile`:
+
 ```ruby
 gem 'dotenv-rails', groups: [:development, :test]
 ```
 
 Create `.env` file:
+
 ```bash
 # .env
 DEVCYCLE_SERVER_SDK_KEY=your_server_sdk_key_here
@@ -297,17 +303,20 @@ RAILS_ENV=development
 ```
 
 Using Rails credentials:
+
 ```bash
 rails credentials:edit
 ```
 
 Add:
+
 ```yaml
 devcycle:
   server_sdk_key: your_server_sdk_key_here
 ```
 
 Then update initialization:
+
 ```ruby
 sdk_key = Rails.application.credentials.devcycle[:server_sdk_key] ||
           ENV['DEVCYCLE_SERVER_SDK_KEY']
@@ -344,6 +353,7 @@ After installation, run your Ruby application and verify everything works with n
 Suggest these as next steps to the user.
 
 After successful installation:
+
 1. Create feature flags via the DevCycle MCP
 2. Implement evaluation context strategies
 3. Set up proper error handling and logging
@@ -360,6 +370,7 @@ After successful installation:
 ## Support
 
 If you encounter issues:
+
 1. Check the official documentation
 2. Review the troubleshooting section above
 3. Contact DevCycle support through the dashboard

--- a/install-prompts/ruby.md
+++ b/install-prompts/ruby.md
@@ -3,11 +3,13 @@
 You are helping to install and configure the DevCycle Ruby SDK in a Ruby server application. Follow this complete guide to successfully integrate DevCycle feature flags. Do not install any Variables as part of this process, the user can ask for you to do that later.
 
 **IMPORTANT: First detect the project configuration:**
+
 - Check if it's a Rails application or plain Ruby
 - Identify the Ruby version (requires Ruby 2.7+)
 - Check for Gemfile and bundler usage
 
 **Do not use the SDK for:**
+
 - Client-side applications (use appropriate client SDKs instead)
 - JavaScript/Node.js applications (use Node.js SDK instead)
 - Mobile applications (use iOS/Android SDKs instead)
@@ -17,6 +19,7 @@ If you detect that the user is trying to have you install the Ruby SDK in an app
 ## Required Information
 
 Before proceeding, use your own analysis, the DevCycle MCP or web search to ensure you have:
+
 - [ ] A DevCycle account and project set up
 - [ ] A Development environment **Server SDK Key** (starts with `dvc_server_`)
 - [ ] Ruby 2.7+ installed
@@ -36,11 +39,13 @@ gem 'devcycle-ruby-server-sdk'
 ```
 
 Then run:
+
 ```bash
 bundle install
 ```
 
 Or install directly:
+
 ```bash
 gem install devcycle-ruby-server-sdk
 ```
@@ -225,11 +230,13 @@ Create environment configuration:
 #### Using dotenv for Rails/Ruby
 
 Add to `Gemfile`:
+
 ```ruby
 gem 'dotenv-rails', groups: [:development, :test]
 ```
 
 Create `.env` file:
+
 ```bash
 # .env
 DEVCYCLE_SERVER_SDK_KEY=your_server_sdk_key_here
@@ -243,6 +250,7 @@ rails credentials:edit
 ```
 
 Add:
+
 ```yaml
 devcycle:
   server_sdk_key: your_server_sdk_key_here
@@ -279,6 +287,7 @@ After installation, run your Ruby application and verify everything works with n
 Suggest these as next steps to the user.
 
 After successful installation:
+
 1. Set up user identification logic for your application
 2. Create your first feature flag via the DevCycle MCP and use it in your controllers
 3. Implement proper error handling for feature flag evaluations
@@ -296,6 +305,7 @@ After successful installation:
 ## Support
 
 If you encounter issues:
+
 1. Check the official documentation
 2. Review the troubleshooting section above
 3. Contact DevCycle support through the dashboard


### PR DESCRIPTION
## Fix Markdown Linter Warnings

**What:** Resolved 25+ markdown linter warnings across all install-prompts files

**Changes:**
- Added blank lines around lists and fenced code blocks (MD032/MD031)
- Fixed duplicate headings and ordered list numbering (MD024/MD029) 
- Added missing language tags to code blocks (MD040)
- Improved code block indentation under list items

**Files:** 29 markdown files in `install-prompts/` directory

**Impact:** Cleaner, more consistent markdown formatting throughout the repository

---

*Note: One remaining false positive in flutter.md where the current formatting is actually correct*

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
