### PR TITLE
fix: correct Python install prompts for OpenFeature provider setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 # macOS
 .DS_Store
 
+# git worktrees
+.worktrees/
+

--- a/install-prompts/python-openfeature.md
+++ b/install-prompts/python-openfeature.md
@@ -33,7 +33,7 @@ Before proceeding, verify using the DevCycle MCP that you have:
 
 - [ ] A DevCycle account and project set up
 - [ ] A Development environment **Server SDK Key** (starts with `dvc_server_`)
-- [ ] Python 3.8+ installed
+- [ ] Python 3.10+ installed
 - [ ] pip or poetry package manager
 - [ ] The most recent OpenFeature and DevCycle provider versions
 
@@ -82,7 +82,7 @@ Before proceeding, verify using the DevCycle MCP that you have:
 pip install openfeature-sdk devcycle-python-server-sdk
 
 # Using poetry
-poetry add openfeature-sdk devcycle-openfeature-provider
+poetry add openfeature-sdk devcycle-python-server-sdk
 ```
 
 ### Step 2: Initialize OpenFeature with DevCycle Provider
@@ -105,7 +105,11 @@ def initialize_feature_flags():
 
     options = DevCycleLocalOptions()
     devcycle_client = DevCycleLocalClient(sdk_key, options)
-    api.set_provider(devcycle_client.get_openfeature_provider())
+
+    # set_provider_and_wait blocks until the provider is ready and raises if the
+    # DevCycle client fails to initialize. set_provider would return immediately and
+    # evaluations would fall back to default values until the provider became ready.
+    api.set_provider_and_wait(devcycle_client.get_openfeature_provider())
 
     # get the OpenFeature client
     open_feature_client = api.get_client()
@@ -178,7 +182,7 @@ Installation is complete when ALL of the following are true:
 ## Common Installation Scenarios
 
 <example scenario="flask_app">
-**Scenario:** Flask application, Python 3.9, pip
+**Scenario:** Flask application, Python 3.11, pip
 **Actions taken:**
 1. ✅ Created .env with server SDK key
 2. ✅ Installed packages via pip
@@ -189,7 +193,7 @@ Installation is complete when ALL of the following are true:
 </example>
 
 <example scenario="django_service">
-**Scenario:** Django REST API, Python 3.8, poetry
+**Scenario:** Django REST API, Python 3.12, poetry
 **Actions taken:**
 1. ✅ Added SDK key to Django settings
 2. ✅ Installed packages via poetry
@@ -211,7 +215,7 @@ Installation is complete when ALL of the following are true:
 3. Check: Is targeting_key provided in context?
 </diagnosis>
 <solution>
-- Call api.set_provider() before getting client
+- Call api.set_provider_and_wait() before getting client, so initialization failures raise instead of returning defaults
 - Verify server SDK key (starts with dvc_server_)
 - Always include targeting_key in EvaluationContext
 </solution>
@@ -221,7 +225,7 @@ Installation is complete when ALL of the following are true:
 <symptom>Module import failures</symptom>
 <diagnosis>
 1. Check: Are packages installed correctly?
-2. Check: Is Python version 3.8+?
+2. Check: Is Python version 3.10+?
 3. Check: Are there dependency conflicts?
 </diagnosis>
 <solution>

--- a/install-prompts/python.md
+++ b/install-prompts/python.md
@@ -34,7 +34,7 @@ Before proceeding, verify using the DevCycle MCP that you have:
 
 - [ ] A DevCycle account and project set up
 - [ ] A Development environment **Server SDK Key** (starts with `dvc_server_`)
-- [ ] Python 3.8+ installed
+- [ ] Python 3.10+ installed
 - [ ] pip or poetry package manager available
 - [ ] The most recent DevCycle Python SDK version available
 


### PR DESCRIPTION
## Summary
- `poetry add` installed `devcycle-openfeature-provider`, which doesn't exist on PyPI (404). Now `devcycle-python-server-sdk`, matching the `pip` line
- Uses `set_provider_and_wait()` in the init example, and fixes the `provider_not_ready` troubleshooting entry, which recommended `api.set_provider()` for the exact symptom `set_provider_and_wait()` prevents
- Corrects the Python floor from 3.8+ to 3.10+ in `python-openfeature.md` and `python.md`, since the SDK declares `python_requires=">=3.10"`. The 3.8 / 3.9 scenario examples were also below the floor
- A separate commit adds `.worktrees/` to `.gitignore`; happy to drop that one if you'd rather keep it out

Matches DevCycleHQ/python-server-sdk#116.

Related: DevCycleHQ/devcycle-docs#982. Note that `docusaurus.config.js` fetches these prompts from `main`, so merging this goes live on the next docs build without a version bump.